### PR TITLE
Add support for UUID schemas

### DIFF
--- a/src/navi/core.clj
+++ b/src/navi/core.clj
@@ -12,6 +12,7 @@
                                            ArraySchema
                                            NumberSchema
                                            BooleanSchema
+                                           UUIDSchema
                                            MediaType]
            [io.swagger.v3.oas.models.parameters PathParameter
                                                 QueryParameter
@@ -85,6 +86,11 @@
   BooleanSchema
   [_]
   boolean?)
+
+(defmethod spec
+  UUIDSchema
+  [_]
+  uuid?)
 
 (defmethod spec
   ObjectSchema

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -9,7 +9,7 @@
             [navi.core :as core])
   (:import [java.util Map LinkedHashMap]
            [io.swagger.v3.oas.models Operation PathItem]
-           [io.swagger.v3.oas.models.media Content StringSchema IntegerSchema ObjectSchema ArraySchema MediaType]
+           [io.swagger.v3.oas.models.media Content StringSchema IntegerSchema ObjectSchema ArraySchema MediaType UUIDSchema]
            [io.swagger.v3.oas.models.parameters Parameter PathParameter QueryParameter RequestBody]))
 
 (deftest map-to-malli-spec
@@ -71,7 +71,10 @@
     (let [arr (doto (ArraySchema.)
                 (.setItems (StringSchema.)))]
       (is (= [:sequential string?]
-             (core/spec arr))))))
+             (core/spec arr)))))
+  (testing "uuid"
+    (is (= uuid?
+           (core/spec (UUIDSchema.))))))
 
 (deftest parameters-to-malli-spec
   (testing "path"


### PR DESCRIPTION
Used when a string type has the [`uuid` format](https://json-schema.org/understanding-json-schema/reference/string.html#resource-identifiers).

E.g.
```yaml
type: object
required:
  - id
properties:
  id:
    type: string
    format: uuid
```