### PR TITLE
Support OpenAPI 3.1.0 JsonSchemas

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
 ; license that can be found in the LICENSE file or at
 ; https://opensource.org/licenses/MIT.
 
-{:deps    {io.swagger.parser.v3/swagger-parser {:mvn/version "2.1.18"}}
+{:deps    {io.swagger.parser.v3/swagger-parser {:mvn/version "2.1.22"}}
  :aliases {:test {:extra-deps {lambdaisland/kaocha    {:mvn/version "1.87.1366"}
                                org.clojure/test.check {:mvn/version "1.1.1"}}
                   :main-opts  ["-m" "kaocha.runner" "--reporter" "kaocha.report.progress/report"]}}}


### PR DESCRIPTION
When using routes-from, the OpenAPI parser is giving me JsonSchema objects rather than the types seen in navi like ObjectSchema and StringSchema. This causes an error when there is no matching dispatch value for `spec`.

 It seems like the only reliable way to tell the "type" of the JsonSchema is to call .getTypes. This also works for ObjectSchema etc., so I changed the spec multimethod to dispatch on the result of .getTypes instead of on the class. This makes navi support any subclasses of Schema, as long as the types can be understood.

UUIDs are distinguished from normal Strings via .getFormat.

Included tests for Schema objects.