### PR TITLE
Add minLength and maxLength support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
 {:deps {io.swagger.parser.v3/swagger-parser {:mvn/version "2.1.22"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
-                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                               metosin/malli {:mvn/version "0.16.4"}}
                   :main-opts ["-m" "cognitect.test-runner"]
                   :exec-fn cognitect.test-runner.api/test}}}


### PR DESCRIPTION
- Rework string spec generation to support the use of malli properties
- Add malli as a test dependency
- Update regex tests to use malli/validate instead of destructuring the spec so that they pass with the new spec generation.
- Test that strings of various lengths validate as expected against the generated spec.

 A simpler implementation is possible using :string and :uuid instead of string? and uuid?, but it breaks many existing tests that check for string? and uuid? specifically.