### PR TITLE
Fix JsonSchema regressions

### DIFF
--- a/src/navi/transform.clj
+++ b/src/navi/transform.clj
@@ -110,10 +110,11 @@
                 "integer" int?
                 "number" number?
                 "string" string?}]
-      (->> schema
-           .getTypes
-           (map pred)
-           (into [:or]))))
+      (if (= 1 (count (.getTypes schema)))
+        (-> schema .getTypes first pred)
+        (->> schema .getTypes
+             (map pred)
+             (into [:or])))))
 
   BinarySchema
   (p/transform [_] any?)

--- a/src/navi/transform.clj
+++ b/src/navi/transform.clj
@@ -122,12 +122,11 @@
                    "number" number?
                    "object" (transform-object schema)
                    "string" string?
-                   (throw (Exception. (str "Unsupported schema" schema)))))]
-      (if (= 1 (count (.getTypes schema)))
-        (-> schema .getTypes first pred)
-        (->> schema .getTypes
-             (map pred)
-             (into [:or])))))
+                   (throw (Exception. (str "Unsupported schema" schema)))))
+          types (.getTypes schema)]
+      (if (= 1 (count types))
+        (-> types first pred)
+        (into [:or] (map pred types)))))
 
   BinarySchema
   (p/transform [_] any?)

--- a/src/navi/transform.clj
+++ b/src/navi/transform.clj
@@ -108,6 +108,7 @@
   (p/transform [schema]
     (let [pred {"boolean" boolean?
                 "integer" int?
+                "null" nil?
                 "number" number?
                 "string" string?}]
       (if (= 1 (count (.getTypes schema)))

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -56,7 +56,8 @@
           props-json (doto (LinkedHashMap.)
                        (.put "x" (IntegerSchema.))
                        (.put "y" (StringSchema.)))
-          obj-json (doto (ObjectSchema.)
+          obj-json (doto (JsonSchema.)
+                     (.addType "object")
                      (.setRequired ["y" "x"])
                      (.setProperties props-json))]
       (is (= [:map {:closed false} [:x int?] [:y string?]]
@@ -69,7 +70,8 @@
   (testing "array"
     (let [arr (doto (ArraySchema.)
                 (.setItems (StringSchema.)))
-          arr-json (doto (ArraySchema.)
+          arr-json (doto (JsonSchema.)
+                     (.addType "array")
                      (.setItems (StringSchema.)))]
       (is (= [:sequential string?]
              (p/transform arr)))

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -172,8 +172,14 @@
   (testing "anyOf"
     (is (= [:or string? int?]
            (p/transform (doto (ComposedSchema.)
-                          (.setAnyOf [(StringSchema.) (IntegerSchema.)]))))))
-  (testing "allOF"
+                          (.setAnyOf [(StringSchema.) (IntegerSchema.)])))))
+    (is (= [:or string? int?]
+           (p/transform (doto (JsonSchema.)
+                          (.setAnyOf [(.types (JsonSchema.) #{"string"}) (.types (JsonSchema.) #{"integer"})]))))))
+  (testing "allOf"
     (is (= [:and string? int?]
            (p/transform (doto (ComposedSchema.)
-                          (.setAllOf [(StringSchema.) (IntegerSchema.)])))))))
+                          (.setAllOf [(StringSchema.) (IntegerSchema.)])))))
+    (is (= [:and string? int?]
+           (p/transform (doto (JsonSchema.)
+                          (.setAllOf [(.types (JsonSchema.) #{"string"}) (.types (JsonSchema.) #{"integer"})])))))))

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -41,7 +41,8 @@
   (testing "number"
     (is (= number? (p/transform (NumberSchema.)))))
   (testing "null"
-    (is (= nil? (p/transform (doto (Schema.) (.addType "null"))))))
+    (is (= nil? (p/transform (doto (Schema.) (.addType "null")))))
+    (is (= nil? (p/transform (doto (JsonSchema.) (.addType "null"))))))
   (testing "empty object"
     (is (= [:map {:closed false}]
            (p/transform (ObjectSchema.)))))


### PR DESCRIPTION
OpenAPI 3.1.0+ definitions are parsed to JsonSchemas. This fixes some regressions introduced by the new Transformable protocol implementation.

- Don't automatically create [:or] schema unless there are multiple options
- Add "null" JsonSchema transform
- Add "array" and "object" JsonSchema transforms
- Add anyOf and allOf support for JsonSchemas