### PR TITLE
Handle numeric min/max bounds

### DIFF
--- a/test/api.yaml
+++ b/test/api.yaml
@@ -94,7 +94,44 @@ paths:
               - type: integer
               - type: string
                 format: uuid
-
+  "/v1/inclusive-interval-integer":
+    get:
+      operationId: GetInclusiveIntervalInteger
+      summary: Get interval data given lower and upper bounds
+      parameters:
+        - name: lower
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: upper
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 119
+  "/v1/inclusive-interval-number":
+    get:
+      operationId: GetInclusiveIntervalNumber
+      summary: Get interval data given lower and upper bounds
+      parameters:
+        - name: lower
+          in: query
+          required: false
+          schema:
+            type: number
+            format: double
+            minimum: 0
+        - name: upper
+          in: query
+          required: false
+          schema:
+            type: number
+            format: double
+            maximum: 119
 components:
   schemas:
     Payload:

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -16,7 +16,9 @@
                            "DeleteIdAndVersion" identity
                            "PostId" identity
                            "HealthCheck" identity
-                           "GetInfoAtTime" identity})
+                           "GetInfoAtTime" identity
+                           "GetInclusiveIntervalInteger" identity
+                           "GetInclusiveIntervalNumber" identity})
            [["/get/{id}/and/{version}"
              {:get
               {:handler identity
@@ -60,4 +62,28 @@
                 [:map
                  [:verbose {:optional true} boolean?]
                  [:foo {:optional true} [:or string? int?]]
-                 [:bar {:optional true} [:and int? uuid?]]]}}}]]))))
+                 [:bar {:optional true} [:and int? uuid?]]]}}}]
+            ["/v1/inclusive-interval-integer"
+             {:get
+              {:handler identity
+               :parameters
+               {:query
+                [:map
+                 [:lower
+                  {:optional true}
+                  [:and int? [:>= 0M]]]
+                 [:upper
+                  {:optional true}
+                  [:and int? [:<= 119M]]]]}}}]
+            ["/v1/inclusive-interval-number"
+             {:get
+              {:handler identity
+               :parameters
+               {:query
+                [:map
+                 [:lower
+                  {:optional true}
+                  [:and number? [:>= 0M]]]
+                 [:upper
+                  {:optional true}
+                  [:and number? [:<= 119M]]]]}}}]]))))


### PR DESCRIPTION
This makes it possible to add `minimum` and `maximum` bounds to numeric values, as documented under [Swagger Data Types](https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers)