### PR TITLE
Default to :any in case schema is not recognized

### DIFF
--- a/test/api.yaml
+++ b/test/api.yaml
@@ -94,7 +94,24 @@ paths:
               - type: integer
               - type: string
                 format: uuid
-
+  "/v1/graphql":
+    get:
+      operationId: RunV1GraphQLQuery
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+            description: "Query string"
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                anyValue: { }
+                nullable: true
 components:
   schemas:
     Payload:

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -16,7 +16,8 @@
                            "DeleteIdAndVersion" identity
                            "PostId" identity
                            "HealthCheck" identity
-                           "GetInfoAtTime" identity})
+                           "GetInfoAtTime" identity
+                           "RunV1GraphQLQuery" identity})
            [["/get/{id}/and/{version}"
              {:get
               {:handler identity
@@ -60,4 +61,13 @@
                 [:map
                  [:verbose {:optional true} boolean?]
                  [:foo {:optional true} [:or string? int?]]
-                 [:bar {:optional true} [:and int? uuid?]]]}}}]]))))
+                 [:bar {:optional true} [:and int? uuid?]]]}}}]
+            ["/v1/graphql"
+             {:get
+              {:handler identity
+               :parameters
+               {:query [:map [:query string?]]},
+               :responses
+               {200
+                {:content {"application/json" {:schema :any}},
+                 :description "OK"}}}}]]))))


### PR DESCRIPTION
Sometimes, it is not possible to nail a specific shape for the data, for instance the data returned from a GraphQL query since the shape of the data will depend on the shape of the query. For this situation, it is possible to specify that the data can be any value using [`anyValue`](https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type) according to the OpenAPI 3 spec.

Unfortunately, the Java swagger-parser library that Navi depends on does not seem to recognize `anyValue`. But the code in the PR attempts to work around that, in the sense that if a schema cannot be identified as a specific schema, it defaults to `:any`, which I think is a sensible default.