### PR TITLE
Preserve the order in the reitit route map from the spec

### DIFF
--- a/src/navi/core.clj
+++ b/src/navi/core.clj
@@ -18,11 +18,12 @@
   [^String api-spec handlers]
   (let [parse-options (doto (ParseOptions.)
                         (.setResolveFully true))
-        contents (.readContents (OpenAPIV3Parser.) api-spec nil parse-options)
-        paths (.getPaths (.getOpenAPI contents))]
-    (->> #(i/path-item->data % handlers)
-         (i/update-kvs paths identity)
-         (mapv identity))))
+        contents (.readContents (OpenAPIV3Parser.) api-spec nil parse-options)]
+    (->> contents
+         .getOpenAPI
+         .getPaths
+         (mapv (fn [[path item]]
+                 [path (i/path-item->data item handlers)])))))
 
 (comment
   (require '[clojure.pprint :as pp])


### PR DESCRIPTION
This preserves the order of routes produced by `routes-from` so that the order is the same as the order read from the file.

Without this change, the test `navi.core-test/full-test` is not guaranteed to succeed.