### PR TITLE
Extend for binary and byte data

### DIFF
--- a/src/navi/transform.clj
+++ b/src/navi/transform.clj
@@ -83,12 +83,17 @@
          (map p/transform)
          (into [compose-as]))))
 
+(def byte-array-class (class (byte-array 0)))
+
+(defn binary-data? [x]
+  (instance? byte-array-class x))
+
 (defn- transform-string
   "Given a StringSchema or a JsonSchema that we know is string-typed,
    return a Malli schema that respects format, length constraints, pattern, and enum."
   [^Schema schema]
   (let [preds {"uuid" uuid?
-               "binary" string?
+               "binary" [:fn binary-data?]
                "byte" string?
                "date" inst?
                "date-time" inst?

--- a/src/navi/transform.clj
+++ b/src/navi/transform.clj
@@ -83,17 +83,12 @@
          (map p/transform)
          (into [compose-as]))))
 
-(def byte-array-class (class (byte-array 0)))
-
-(defn binary-data? [x]
-  (instance? byte-array-class x))
-
 (defn- transform-string
   "Given a StringSchema or a JsonSchema that we know is string-typed,
    return a Malli schema that respects format, length constraints, pattern, and enum."
   [^Schema schema]
   (let [preds {"uuid" uuid?
-               "binary" [:fn binary-data?]
+               "binary" bytes?
                "byte" string?
                "date" inst?
                "date-time" inst?

--- a/test/api.yaml
+++ b/test/api.yaml
@@ -168,6 +168,15 @@ paths:
                   description: "optional query name"
               required:
                 - query
+  "/raw":
+    post:
+      operationId: ProvideRawData
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
 
 components:
   schemas:

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -119,6 +119,4 @@
               {:handler identity
                :parameters
                {:body
-                [:or
-                 nil?
-                 [:fn transform/binary-data?]]}}}]]))))
+                [:or nil? bytes?]}}}]]))))

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -7,7 +7,8 @@
 (ns navi.core-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [navi.core :as c]))
+   [navi.core :as c]
+   [navi.transform :as transform]))
 
 (deftest full-test
   (testing "full route tree"
@@ -20,7 +21,8 @@
                            "GetInclusiveIntervalInteger" identity
                            "GetInclusiveIntervalNumber" identity
                            "GetMinMaxNumber" identity
-                           "RunV2GraphQLQuery" identity})
+                           "RunV2GraphQLQuery" identity
+                           "ProvideRawData" identity})
            [["/get/{id}/and/{version}"
              {:get
               {:handler identity
@@ -111,4 +113,12 @@
                   string?]
                  [:operationName
                   {:optional true}
-                  string?]]}}}]]))))
+                  string?]]}}}]
+            ["/raw"
+             {:post
+              {:handler identity
+               :parameters
+               {:body
+                [:or
+                 nil?
+                 [:fn transform/binary-data?]]}}}]]))))

--- a/test/navi/core_test.clj
+++ b/test/navi/core_test.clj
@@ -7,8 +7,7 @@
 (ns navi.core-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [navi.core :as c]
-   [navi.transform :as transform]))
+   [navi.core :as c]))
 
 (deftest full-test
   (testing "full route tree"

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -8,7 +8,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
-   [navi.protocols :as p])
+   [navi.protocols :as p]
+   [navi.transform])
   (:import
    [io.swagger.v3.oas.models.media
     ArraySchema

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -8,8 +8,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
-   [navi.protocols :as p]
-   [navi.transform :refer [binary-data?]])
+   [navi.protocols :as p])
   (:import
    [io.swagger.v3.oas.models.media
     ArraySchema
@@ -225,10 +224,3 @@
            (p/transform (doto (JsonSchema.)
                           (.setAllOf [(.types (JsonSchema.) #{"string"})
                                       (.types (JsonSchema.) #{"integer"})])))))))
-
-(deftest binary-data-test
-  (is (binary-data? (byte-array [1 2 3])))
-  (is (not (binary-data? :a)))
-  (is (not (binary-data? 119)))
-  (is (not (binary-data? [])))
-  (is (not (binary-data? (int-array [1 2 3])))))

--- a/test/navi/transform_test.clj
+++ b/test/navi/transform_test.clj
@@ -9,7 +9,7 @@
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
    [navi.protocols :as p]
-   [navi.transform])
+   [navi.transform :refer [binary-data?]])
   (:import
    [io.swagger.v3.oas.models.media
     ArraySchema
@@ -225,3 +225,10 @@
            (p/transform (doto (JsonSchema.)
                           (.setAllOf [(.types (JsonSchema.) #{"string"})
                                       (.types (JsonSchema.) #{"integer"})])))))))
+
+(deftest binary-data-test
+  (is (binary-data? (byte-array [1 2 3])))
+  (is (not (binary-data? :a)))
+  (is (not (binary-data? 119)))
+  (is (not (binary-data? [])))
+  (is (not (binary-data? (int-array [1 2 3])))))


### PR DESCRIPTION
This adds support for schemas on the form `{"type": "string", "format": "binary"}`.

The unit tests seem to fail without the changes in PR #18 . 